### PR TITLE
feature: Adding meta properties to Section

### DIFF
--- a/src/ScrollingProvider.tsx
+++ b/src/ScrollingProvider.tsx
@@ -10,7 +10,14 @@ type Props = {
   children: ReactNode;
 };
 
+type RegisterRefsArgs = {
+  id: string;
+  meta: unknown;
+}
+
 const REFS: RefsRegister = {};
+const META: Meta = {};
+
 if (typeof window !== 'undefined') {
   smoothscroll.polyfill();
 }
@@ -55,9 +62,10 @@ const ScrollingProvider = ({
 
   const debounceScroll = debounce(handleScroll, debounceDelay);
 
-  const registerRef = (id: string) => {
+  const registerRef = ({id, meta}: {id: string, meta: unknown}) => {
     const ref = React.createRef<HTMLElement>();
     REFS[id] = ref;
+    META[id] = meta;
     return ref;
   };
 
@@ -79,6 +87,7 @@ const ScrollingProvider = ({
       registerRef,
       scrollTo,
       refs: REFS,
+      meta: META,
       selected,
     }),
     [selected, REFS],

--- a/src/Section.tsx
+++ b/src/Section.tsx
@@ -3,12 +3,13 @@ import { ScrollContext } from './context';
 
 type Props = {
   id: string;
+  meta: unknown;
   children: React.ReactNode;
 } & React.HTMLProps<HTMLButtonElement>;
 
-const Section = ({ id, children, ...rest }: Props) => {
+const Section = ({ id, children, meta, ...rest }: Props) => {
   const { registerRef } = useContext(ScrollContext);
-  const ref = useMemo(() => registerRef(id), [id]);
+  const ref = useMemo(() => registerRef({id, meta}), [id]);
 
   return (
     <section {...rest} ref={ref} id={id}>

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,7 @@ import React from 'react';
 const DEFAULT_CONTEXT = {
   selected: '',
   refs: {},
+  meta: {},
   scrollTo: () => {},
   registerRef: () => null,
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,9 +2,14 @@ type RefsRegister = {
   [x: string]: RefObject<HTMLElement>;
 };
 
+type Meta = {
+  [id: string]: unknown;
+};
+
 type ScrollContextType = {
-  registerRef: (id: string) => RefObject<HTMLElement> | null;
+  registerRef: ({id: string, meta: unknown}) => RefObject<HTMLElement> | null;
   scrollTo: (section: string) => void;
   refs: RefsRegister;
+  meta: Meta;
   selected: string;
 };

--- a/src/useScrollSection.ts
+++ b/src/useScrollSection.ts
@@ -10,12 +10,13 @@ export const useScrollSection = (id: string) => {
 };
 
 export const useScrollSections = () => {
-  const { scrollTo, selected: selectedSection, refs } = useContext(
+  const { scrollTo, selected: selectedSection, refs, meta } = useContext(
     ScrollContext,
   );
 
   const sections = Object.keys(refs).map((id) => ({
     id,
+    meta: meta[id],
     onClick: () => scrollTo(id),
     selected: selectedSection === id,
   }));


### PR DESCRIPTION
Currently, you only get access to the `id` passed into `<Section>`s when you retrieve section information later with the `useScrollSections()` hook.  This PR allows you to pass through extra information that might be useful.

In my case, I wanted to have a title that wasn't dependent on the ID when using @EmaSuriano's [gatsby-starter-mate](https://github.com/EmaSuriano/gatsby-starter-mate), specifically so I could have titles with spaces in them and continue to
use internal Markdown links.