### PR TITLE
Add check if the ref has a current

### DIFF
--- a/src/ScrollingProvider.tsx
+++ b/src/ScrollingProvider.tsx
@@ -41,6 +41,11 @@ const ScrollingProvider = ({
   const handleScroll = () => {
     const selectedSection = Object.keys(REFS).reduce(
       (acc, id) => {
+        if (!REFS[id].current) return {
+          id: id,
+          differenceFromTop: 0
+        }
+        
         const { top } = REFS[id].current.getBoundingClientRect();
         const differenceFromTop = Math.abs(top);
 


### PR DESCRIPTION
Add a check if the current ref exists.

In reality I think this lib was thought for a single page, which makes sense that it stores everything in the context.
If you have a more complex page where the stuff changes problems start. specially with SSR, which basically stores the status of the previous pages.so if you load a page SSR you will see wrong data in the sections until client side kicks in.

#98 